### PR TITLE
specfile: Add op5-monitor-user requirement

### DIFF
--- a/op5build/check_aws.spec
+++ b/op5build/check_aws.spec
@@ -13,6 +13,7 @@ Group: op5/system-addons
 URL: http://www.op5.com/support
 Prefix: /opt/plugins
 Requires: python36
+Requires: op5-monitor-user
 BuildRequires: python36
 Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}
@@ -68,5 +69,7 @@ cd %{app_install_path}
 rm -rf %buildroot
 
 %changelog
+* Thu May 28 2020 Jacob Hansen <jhansen@op5.com> - 0.2.0
+- Require op5-monitor-user
 * Fri Oct 11 2019 Robert Wikman <rwikman@op5.com> - 0.1.0
 - Init


### PR DESCRIPTION
This commit adds the package `op5-monitor-user` as a requirement. This
is needed as otherwise the package might be installed before the `monitor`
user is present on the system causing a lot of the following warnings to
appear during the installation.

`warning: user monitor does not exist - using root`

Signed-off-by: Jacob Hansen <jhansen@op5.com>