### PR TITLE
Run check_aws.py in isolated mode

### DIFF
--- a/profiles/op5_monitor.py
+++ b/profiles/op5_monitor.py
@@ -1,4 +1,4 @@
-#!/opt/monitor/op5/check_aws/venv/bin/python
+#!/opt/monitor/op5/check_aws/venv/bin/python -I
 
 from check_aws.__main__ import main
 


### PR DESCRIPTION
Due to the check_aws name being shared between the package and the
rpmbuild-installed check_aws.py script, the script attempts to import
`__main__` from self, rather than from the check_aws package.

The easiest fix would be to simply rename the script file, but that
would cause breakage.

In isolated mode (-I in the hashbang) sys.path contains neither the
script's directory nor the user's site-packages directory, which fixes
this issue.