### PR TITLE
Add initial Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "ITRS-Group/team-b"


### PR DESCRIPTION
Dependabot works straight out of the box without but if one wants to be
able to assign Dependabot created PRs to a specific user or team one
needs to supply a config file.

In this commit we add config for the mandatory options
package-ecosystem, directory and schedule.interval together with the
reviewers option.

Signed-off-by: Daniel Nilsson <dnilsson@itrsgroup.com>