### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       interval: "daily"
     reviewers:
       - "ITRS-Group/team-b"
+    ignore:
+      - dependency-name: boto3
+        # For boto3 we ignore all 1.17.x updates
+        versions: 1.17.x


### PR DESCRIPTION
With this commit we tell Dependabot to ignore all boto3 1.17.x updates.
Boto3 project has a bot that frequently bumps minor version, often
without code changes. We do not want to trigger Dependabot to create PRs
at the same frequencey.

Signed-off-by: Daniel Nilsson <dnilsson@itrsgroup.com>