### PR TITLE
Feature/update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
       interval: "daily"
     reviewers:
       - "ITRS-Group/team-b"
-    ignore:
-      - dependency-name: boto3
-        # For boto3 we ignore all 1.17.x updates
-        versions: 1.17.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     reviewers:
       - "ITRS-Group/team-b"


### PR DESCRIPTION
We remove the ignore patch level version update that did not work. We add config to now run dependabot once every week, on sundays.