### PR TITLE
spec: Obsolete previous noarch releases

### DIFF
--- a/op5build/monitor-plugin-check_aws.spec
+++ b/op5build/monitor-plugin-check_aws.spec
@@ -25,6 +25,10 @@ Requires: python36
 Requires(post): python36
 BuildRequires: python36
 %endif
+# This package has changed from noarch to arch specific. Therefor obsolete
+# everything before the last released noarch package (v2021.5.1), to avoid yum
+# "Error: Protected multilib versions".
+Obsoletes: %{name} <= 2021.5.1-op5.2
 
 %description
 Nagios plugin for monitoring CloudWatch-enabled AWS services
@@ -86,6 +90,8 @@ fi
 rm -rf %buildroot
 
 %changelog
+* Mon May 31 2021 Aksel Sjögren <asjogren@itrsgroup.com>
+- Obsolete previous noarch releases of the package.
 * Mon May  3 2021 Aksel Sjögren <asjogren@itrsgroup.com> - v2021.5.1
 - Remove dependency on op5-monitor-user.
 - Disable creation of debug package.


### PR DESCRIPTION
Fix yum error "Error: Protected multilib versions" when upgrading from
previous noarch- versions.

This packages architecture changed from noarch to arch-dependent in
5d49ecf. That caused the above error when updating from a noarch to
x86_64 package.
Therefore this and any future versions will obsolete 2021.5.1 and
earlier, so that any yum updates to future versions, yum will replace
pkg.noarch with pkg.x86_64.

Reference: https://docs.fedoraproject.org/en-US/packaging-guidelines/#renaming-or-replacing-existing-packages

This fixes MON-12761.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>