### PR TITLE
Add explicit dependency on python3 intepreter

### DIFF
--- a/op5build/monitor-plugin-check_aws.spec
+++ b/op5build/monitor-plugin-check_aws.spec
@@ -17,6 +17,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}
 AutoReq: no
 %if 0%{?rhel} >= 8
 BuildRequires: python3-devel
+Requires: python3
 Requires: python3-boto3
 Requires: python3-dataclasses
 Requires: python3-nagiosplugin


### PR DESCRIPTION
While it happen to works on a normal OP5 Monitor installation, it
doesn't on a minimal centos8 install, like the VM the post-install tests
runs on, because Python 3 is not installed as `/usr/bin/python36` as the
check_aws entrypoint requires since it was built with the python3-devel
environment.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>