### PR TITLE
Add python 3.9 as a requriement in post

### DIFF
--- a/op5build/monitor-plugin-check_aws.spec
+++ b/op5build/monitor-plugin-check_aws.spec
@@ -18,6 +18,7 @@ AutoReq: no
 %if 0%{?rhel} >= 8
 BuildRequires: python39-devel
 BuildRequires: python39-pip
+Requires(post): python39
 %else
 Requires: python36
 Requires(post): python36


### PR DESCRIPTION
This commit adds python 3.9 as a requriement in post install since we create the venv at that step. This will prevent potential errors in case that the host does not yet have python 3.9 installed.

This is part of MON-13261.

Signed-off-by: Jerson Dumalaon jdumalaon@itrsgroup.com