### PR TITLE
Use profile arg

### DIFF
--- a/check_aws/resource.py
+++ b/check_aws/resource.py
@@ -16,7 +16,9 @@ from .exceptions import (
 class CloudWatchResource(nagiosplugin.Resource):
     def __init__(self, cmdargs, *args, **kwargs):
         self.cmdargs = cmdargs
-        self.session = boto3.Session(region_name=cmdargs.region)
+        self.session = boto3.Session(
+            region_name=cmdargs.region, profile_name=cmdargs.profile
+        )
         super(CloudWatchResource, self).__init__(*args, **kwargs)
 
     def _query_make(self, cmdargs, validate=True):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,14 @@ def test_non_file(cli):
         cli({**CLI_DEFAULTS, "--credentials": None})
 
 
+def test_profile_default(cli):
+    assert cli(CLI_DEFAULTS).profile == CommandArguments.profile
+
+
+def test_profile_valid(cli):
+    assert cli({**CLI_DEFAULTS, "-p": "test"}).profile == "test"
+
+
 def test_namespace_valid(cli):
     assert cli({**CLI_DEFAULTS, "-n": "test"}).namespace == "test"
     assert cli({**CLI_DEFAULTS, "-n": "test123"}).namespace == "test123"


### PR DESCRIPTION
This commit enables usage of the profile argument by adding it to the
boto3 session. Previously, the profile argument was ignored.

This resolves MON-13367.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>